### PR TITLE
Fix numpy indexing issue

### DIFF
--- a/smithplot/smithaxes.py
+++ b/smithplot/smithaxes.py
@@ -1063,11 +1063,11 @@ class SmithAxes(Axes):
 
                             x_div, y_div = d_mat[i, k]
 
-                            for xs in np.linspace(x0, x1, x_div + 1)[1:]:
+                            for xs in np.linspace(x0, x1, int(x_div) + 1)[1:]:
                                 x_lines.append([xs, y0, y1])
                                 x_lines.append([xs, -y1, -y0])
 
-                            for ys in np.linspace(y0, y1, y_div + 1)[1:]:
+                            for ys in np.linspace(y0, y1, int(y_div) + 1)[1:]:
                                 y_lines.append([ys, x0, x1])
                                 y_lines.append([-ys, x0, x1])
 


### PR DESCRIPTION
On Python 3.11.2 with numpy 1.24.3 I get the following indexing error:
```
  File "/mnt/mstorage/Projects/Python/beadpull/.venv/lib/python3.11/site-packages/smithplot/smithaxes.py", line 1070, in grid
    for ys in np.linspace(y0, y1, y_div + 1)[1:]:
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<__array_function__ internals>", line 200, in linspace
  File "/mnt/mstorage/Projects/Python/beadpull/.venv/lib/python3.11/site-packages/numpy/core/function_base.py", line 121, in linspace
    num = operator.index(num)
          ^^^^^^^^^^^^^^^^^^^
TypeError: 'numpy.float64' object cannot be interpreted as an integer
```

This PR fixes this error.